### PR TITLE
Add license metadata to a package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/Pliner/aio-throttle",
     packages=["aio_throttle"],
-    classifiers=[],
+    license="MIT",
+    classifiers=["License :: OSI Approved :: MIT License"],
     python_requires='>=3.7',
     package_data={'aio_throttle': ['py.typed']},
 )


### PR DESCRIPTION
Some tools for Python package metadata inspection rely on the trove classifiers and license fields in the `setup.py`.
Let's add them